### PR TITLE
#1 Improved responsivness for screens < 600px

### DIFF
--- a/style.css
+++ b/style.css
@@ -117,3 +117,20 @@ h1 {
 .label-score {
   margin-bottom: 2rem;
 }
+
+/* Responsivness rules */
+@media only screen and (max-width: 600px) {
+  html {
+    font-size: 35%;
+  }
+  main {
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: start;
+    gap: 24px;
+  }
+  .right {
+    margin-top: 10rem;
+    text-align: center;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -119,6 +119,15 @@ h1 {
 }
 
 /* Responsivness rules */
+
+/* Large screens */
+@media only screen and (min-width: 1920px) {
+  html {
+    font-size: 100%;
+  }
+}
+
+/* Small screens */
 @media only screen and (max-width: 600px) {
   html {
     font-size: 35%;


### PR DESCRIPTION
The solution is far from perfect, but it's simple enough project. Let me know what you think!
![image](https://github.com/Aman254/guessMyNumber-Game/assets/83674512/25cfbeb4-4d1e-4288-a1d5-ecc5a57def9e)
![image](https://github.com/Aman254/guessMyNumber-Game/assets/83674512/b99e8574-33c7-4d82-a688-053bd4f9c54e)

Only at around ~295 width screens it starts to break again which is fine because there shouldn't be many phones at these sizes, my guess is it's because of font size. CSS should be restructurized to take into consideration responsivness from the beginning to make the app fully responsive with cleaner solutions.